### PR TITLE
fix: melt の var_name をスカラに修正（["time"] -> "time"）

### DIFF
--- a/03-table-data/03-02-reshaping.ipynb
+++ b/03-table-data/03-02-reshaping.ipynb
@@ -847,7 +847,7 @@
     "pivoted_tips.melt(\n",
     "    id_vars=[\"smoker\"],\n",
     "    value_vars=[\"Dinner\", \"Lunch\"],\n",
-    "    var_name=[\"time\"],\n",
+    "    var_name=\"time\",\n",
     "    value_name=\"total_bill\",\n",
     ")"
    ]


### PR DESCRIPTION
var_name は生成される列名を表すスカラを指定する引数で、複数列を選ぶ
id_vars / value_vars とは異なりリストにしない（pandas 2.0.3 の docstring でも var_name : scalar と明記）。リスト指定はサンプルの対応バージョン
（pandas 2.0.3）では動作するが、pandas 3.0 では
ValueError: var_name=['time'] must be a scalar. になる。 スカラ指定は両バージョンで同一の正しい結果になる後方互換の修正。